### PR TITLE
V1.4.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-${PYTHON} -m pip install . --no-deps -vv
+${PYTHON} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,8 +67,6 @@ test:
     - hypothesis
     - shapely
     - aiohttp
-    # - pytest-randomly
-    # - cython>=3.0
 
   files:
     - test_data/test.tif

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.10" %}
+{% set version = "1.4.3" %}
 
 package:
   name: rasterio
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/mapbox/rasterio/archive/{{ version }}.tar.gz
-  sha256: 0da4bea271a7f2ef2c44f528245a4f5c76ec635d075a0bd834300c75924b62c5
+  sha256: dfa248fdc46f0e08ab957712b13a86d7cd49bce72f34b7fdca94af3b2d850181
 
 build:
   number: 0
@@ -21,10 +21,10 @@ requirements:
   host:
     - python
     - pip
-    - cython >=3.0.2, < 3.1.0
-    - numpy
+    - cython >=3.0.2,< 3.1.0
+    - numpy 2
     - libgdal
-    - setuptools
+    - setuptools>=67.8
     - wheel
   run:
     - python
@@ -35,14 +35,24 @@ requirements:
     - click-plugins
     - cligj >=0.5
     - libgdal
-    - setuptools
-    - snuggs >=1.4.1
+    # - setuptools
+    # - snuggs >=1.4.1
     - importlib-metadata  # [py<310]
-    - {{ pin_compatible('numpy') }}
+    - numpy >=1.24
+    - pyparsing
+
+{% set tests_to_skip = "_not_a_real_test" %}
+
+# Skipping geolocation warp tests due to minor numerical variations in reprojected output.
+{% set tests_to_skip = tests_to_skip + " or test_geoloc_warp_array" %}
+{% set tests_to_skip = tests_to_skip + " or test_geoloc_warp_dataset" %}
+{% set tests_to_skip = tests_to_skip + " or test_geoloc_warp_array_subsampled" %}
 
 test:
   source_files:
     - tests
+    # Needed to provide pytest markers
+    - setup.cfg
   imports:
     - rasterio
   requires:
@@ -50,26 +60,24 @@ test:
     - pytest >=2.8.2
     - pytest-cov >=2.2.0
     - ipython>=2.0
-    - boto3 >=1.3.1
-    - matplotlib-base
+    - boto3 >=1.2.4
+    - fsspec
     - packaging
     - hypothesis
     - shapely
+    - aiohttp
+    - pytest-randomly
+    - cython>=3.0
 
   files:
     - test_data/test.tif
+
   commands:
     - pip check
     - rio --help
-    - rio info {{ RECIPE_DIR }}/test_data/test.tif  # [not win]
-    - rio info {{ RECIPE_DIR }}\\test_data\\test.tif  # [win]
-    # test_target_aligned_pixels is failing for all OSes for proj 8.0.0
-    # skip linux tests for cross-compiled targets
-    - $PYTHON -m pytest -v -m "not wheel" -rxXs -k "not (test_target_aligned_pixels or test_info_azure_unsigned)" tests  # [linux and build_platform == target_platform]
-    - $PYTHON -m pytest -v -m "not wheel" -rxXs -k "not (test_target_aligned_pixels or test_outer_boundless_pixel_fidelity or test_info_azure_unsigned)" tests  # [linux and build_platform == target_platform]
-    - $PYTHON -m pytest -v -m "not wheel" -rxXs -k "not (test_target_aligned_pixels or test_reproject_error_propagation or test_outer_boundless_pixel_fidelity)" tests  # [osx]
-    - python -m pytest -v -m "not wheel" -rxXs -k "not (test_hit_ovr or test_file_in_handler_with_vfs or test_files or test_parse_windows_path or test_copyfiles_same_dataset_another_name or test_context or test_target_aligned_pixels or test_decimated_no_use_overview or test_reproject_error_propagation)" tests  # [win]
-
+    - rio info {{ RECIPE_DIR }}/test_data/test.tif
+    - python -m pytest -v -m "not wheel" -rxXs -k "not ({{ tests_to_skip }})" tests
+    
 about:
   home: https://github.com/mapbox/rasterio
   license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,6 +66,7 @@ test:
     - packaging
     - hypothesis
     - shapely
+    - aiohttp
 
   files:
     - test_data/test.tif

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,9 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_geoloc_warp_dataset" %}
 {% set tests_to_skip = tests_to_skip + " or test_geoloc_warp_array_subsampled" %}
 
+# E   FileExistsError: [WinError 183] Cannot create a file when that file already exists:
+{% set tests_to_skip = tests_to_skip + " or test_decimated_no_use_overview" %}  # [win]
+
 test:
   source_files:
     - tests
@@ -77,7 +80,7 @@ test:
     - rio --help
     - rio info {{ RECIPE_DIR }}/test_data/test.tif
     - python -m pytest -v -m "not wheel" -rxXs -k "not ({{ tests_to_skip }})" tests
-    
+
 about:
   home: https://github.com/mapbox/rasterio
   license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,10 +21,10 @@ requirements:
   host:
     - python
     - pip
-    - cython >=3.0.2,< 3.1.0
+    - cython >=3.0.2,<3.1.0
     - numpy 2
     - libgdal
-    - setuptools>=67.8
+    - setuptools >=67.8
     - wheel
   run:
     - python
@@ -35,8 +35,6 @@ requirements:
     - click-plugins
     - cligj >=0.5
     - libgdal
-    # - setuptools
-    # - snuggs >=1.4.1
     - importlib-metadata  # [py<310]
     - numpy >=1.24
     - pyparsing
@@ -69,8 +67,8 @@ test:
     - hypothesis
     - shapely
     - aiohttp
-    - pytest-randomly
-    - cython>=3.0
+    # - pytest-randomly
+    # - cython>=3.0
 
   files:
     - test_data/test.tif
@@ -90,7 +88,7 @@ about:
      Rasterio reads and writes these formats and provides a Python API based on N-D arrays.
   summary: 'Rasterio reads and writes geospatial raster datasets'
   dev_url: https://github.com/mapbox/rasterio
-  doc_url: https://rasterio.readthedocs.io/en/latest/
+  doc_url: https://rasterio.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,6 @@ test:
     - packaging
     - hypothesis
     - shapely
-    - aiohttp
 
   files:
     - test_data/test.tif


### PR DESCRIPTION
rasterio v1.4.3

**Destination channel:** defaults

### Links

- [PKG-6387](https://anaconda.atlassian.net/browse/PKG-6387) 
- [Upstream repository](https://github.com/rasterio/rasterio/tree/1.4.3)
- [Upstream changelog/diff](https://github.com/rasterio/rasterio/releases/tag/1.4.3)
- [setup.py](https://github.com/rasterio/rasterio/blob/1.4.3/setup.py#L248-L280)

### Explanation of changes:

- Bump version and SHA
- Build for 3.13
- Update dependencies
- Cleanup test area and minimize skips.

### Notes
- I skipped building the last commit when I just removed some commented lines. To see logs please look at the previous commit. 



[PKG-6387]: https://anaconda.atlassian.net/browse/PKG-6387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ